### PR TITLE
Update __init__.py for Home Assiatant 2025.6

### DIFF
--- a/custom_components/ezviz_plug/__init__.py
+++ b/custom_components/ezviz_plug/__init__.py
@@ -19,7 +19,7 @@ async def async_setup_entry(hass: core.HomeAssistant, entry: config_entries.Conf
 
     # Forward the setup to the switch platform.
     hass.async_create_task(
-        hass.config_entries.async_forward_entry_setup(entry, "switch")
+        hass.config_entries.async_forward_entry_setups(entry, "switch")
     )
 
     return True


### PR DESCRIPTION
For working with Home assistant 2025.6

Warning message :
Detected that custom integration 'ezviz_plug' calls async_forward_entry_setup for integration, ezviz_plug with title: xxxxxxxxxxxxxxxxx which is deprecated, await async_forward_entry_setups instead at custom_components/ezviz_plug/__init__.py, line 22:  await hass.config_entries.async_forward_entry_setup(entry, "switch").  This will stop working in Home Assistant 2025.6, please create a bug report at https://github.com/khal3d/homeassistant-ezviz-smart-plug/issues